### PR TITLE
Fix/segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.o
 *.a
 Makefile.bak
+yak

--- a/main.c
+++ b/main.c
@@ -62,6 +62,11 @@ int main_count(int argc, char *argv[])
 		fprintf(stderr, "WARNING: counts are inexact if -k is greater than 31\n");
 	}
 	h = yak_count(argv[o.ind], &opt, 0);
+	if(!h)
+	{
+		fprintf(stderr, "ERROR: file %s does not exist.\n", argv[o.ind]);
+		return 1;
+	}
 	if (opt.bf_shift > 0) {
 		yak_ch_destroy_bf(h);
 		yak_ch_clear(h, opt.n_thread);


### PR DESCRIPTION
When working on a file that doesn't exist, a segfault occurs:
```
./yak count -k31 -b37 -t16 -o pat.yak paternal.fq.gz
[1]    27444 segmentation fault (core dumped)  ./yak count -k31 -b37 -t16 -o pat.yak paternal.fq.gz
```

This mr fixes it with the following behavior:
```
./yak count -k31 -b37 -t16 -o pat.yak paternal.fq.gz
ERROR: file paternal.fq.gz does not exist.
```

Also, add the binary output to gitignore.
